### PR TITLE
fix Index 1 out of bounds length 0 on createLut(Attributes)

### DIFF
--- a/src/main/java/org/dcm4che3/img/DicomImageUtils.java
+++ b/src/main/java/org/dcm4che3/img/DicomImageUtils.java
@@ -143,7 +143,7 @@ public class DicomImageUtils {
         LOGGER.error("Cannot get byte[] of {}", TagUtils.toString(Tag.LUTData), e);
       }
 
-      if (bData == null) {
+      if (bData == null | bData.length == 0) {
         return Optional.empty();
       }
 


### PR DESCRIPTION
Hello, for some particular images I had the following error:

```
Exception in thread "main" java.lang.ArrayIndexOutOfBoundsException: Index 1 out of bounds for length 0
	at org.dcm4che3.util.ByteUtils.bytesToShortsLE(ByteUtils.java:92)
	at org.dcm4che3.util.ByteUtils.bytesToShorts(ByteUtils.java:86)
	at org.dcm4che3.img.DicomImageUtils.createLut(DicomImageUtils.java:171)
	at org.dcm4che3.img.lut.VoiLutModule.lambda$init$1(VoiLutModule.java:88)
	at java.base/java.util.stream.ReferencePipeline$3$1.accept(ReferencePipeline.java:197)
	at java.base/java.util.ArrayList$ArrayListSpliterator.forEachRemaining(ArrayList.java:1625)
	at java.base/java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:509)
	at java.base/java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:499)
	at java.base/java.util.stream.ReduceOps$ReduceOp.evaluateSequential(ReduceOps.java:921)
	at java.base/java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:234)
	at java.base/java.util.stream.ReferencePipeline.collect(ReferencePipeline.java:682)
	at org.dcm4che3.img.lut.VoiLutModule.init(VoiLutModule.java:89)
	at org.dcm4che3.img.lut.VoiLutModule.<init>(VoiLutModule.java:55)
	at org.dcm4che3.img.stream.ImageDescriptor.<init>(ImageDescriptor.java:82)
	at org.dcm4che3.img.stream.ImageDescriptor.<init>(ImageDescriptor.java:52)
	at org.dcm4che3.img.DicomMetaData.<init>(DicomMetaData.java:34)
	at org.dcm4che3.img.stream.DicomFileInputStream.getMetadata(DicomFileInputStream.java:42)
	at org.dcm4che3.img.DicomImageReader.getStreamMetadata(DicomImageReader.java:192)
	at org.example.Main.main(Main.java:30)
```

In my case the LutData length is 0 and we try to browse bData in the ByteUtils.bytesToShortsLE method, which causes the error ArrayIndexOutOfBoundsException: Index 1 out of bounds for length 0.

To solve this problem, I opened this PR. Thanks in advance